### PR TITLE
Use SHA256 for cache keys

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -232,7 +232,7 @@ class ApplicationController < ActionController::Base
     :usage_rights_discussion_topics, :inline_math_everywhere, :granular_permissions_manage_users,
     :canvas_for_elementary
   ].freeze
-  JS_ENV_FEATURES_HASH = Digest::MD5.hexdigest([JS_ENV_SITE_ADMIN_FEATURES + JS_ENV_ROOT_ACCOUNT_FEATURES].sort.join(",")).freeze
+  JS_ENV_FEATURES_HASH = Digest::SHA256.hexdigest([JS_ENV_SITE_ADMIN_FEATURES + JS_ENV_ROOT_ACCOUNT_FEATURES].sort.join(",")).freeze
   def cached_js_env_account_features
     # can be invalidated by a flag change on either site admin or the domain root account
     MultiCache.fetch(["js_env_account_features", JS_ENV_FEATURES_HASH,

--- a/app/controllers/context_modules_controller.rb
+++ b/app/controllers/context_modules_controller.rb
@@ -48,7 +48,7 @@ class ContextModulesController < ApplicationController
       @modules_cache_key ||= begin
         visible_assignments = @current_user.try(:assignment_and_quiz_visibilities, @context)
         cache_key_items = [@context.cache_key, @can_edit, @is_student, @can_view_unpublished, 'all_context_modules_draft_10',
-          collection_cache_key(@modules), Time.zone, Digest::MD5.hexdigest([visible_assignments, @section_visibility].join("/"))]
+          collection_cache_key(@modules), Time.zone, Digest::SHA256.hexdigest([visible_assignments, @section_visibility].join("/"))]
         cache_key = cache_key_items.join('/')
         cache_key = add_menu_tools_to_cache_key(cache_key)
         cache_key = add_mastery_paths_to_cache_key(cache_key, @context, @current_user)
@@ -358,7 +358,7 @@ class ContextModulesController < ApplicationController
       end
 
       submitted_assignment_ids = if @current_user && assignment_ids.any?
-        assignments_key = Digest::MD5.hexdigest(assignment_ids.sort.join(","))
+        assignments_key = Digest::SHA256.hexdigest(assignment_ids.sort.join(","))
         Rails.cache.fetch_with_batched_keys("submitted_assignment_ids/#{assignments_key}",
             batch_object: @current_user, batched_keys: :submissions) do
           @current_user.submissions.shard(@context.shard).

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1873,7 +1873,7 @@ class CoursesController < ApplicationController
         id = split.pop
         (types[split.join("_")] ||= []) << id
       end
-      locks_hash = Rails.cache.fetch(['locked_for_results', @current_user, Digest::MD5.hexdigest(params[:assets])].cache_key) do
+      locks_hash = Rails.cache.fetch(['locked_for_results', @current_user, Digest::SHA256.hexdigest(params[:assets])].cache_key) do
         locks = {}
         types.each do |type, ids|
           if type == 'assignment'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -464,7 +464,7 @@ module ApplicationHelper
   def safe_cache_key(*args)
     key = args.cache_key
     if key.length > 200
-      key = Digest::MD5.hexdigest(key)
+      key = Digest::SHA256.hexdigest(key)
     end
     key
   end
@@ -857,7 +857,7 @@ module ApplicationHelper
   # if you can avoid loading the list at all, that's even better, of course.
   def collection_cache_key(collection)
     keys = collection.map { |element| element.cache_key }
-    Digest::MD5.hexdigest(keys.join('/'))
+    Digest::SHA256.hexdigest(keys.join('/'))
   end
 
   def add_uri_scheme_name(uri)

--- a/app/helpers/context_modules_helper.rb
+++ b/app/helpers/context_modules_helper.rb
@@ -39,7 +39,7 @@ module ContextModulesHelper
     if context_module
       visible_assignments = user ? user.assignment_and_quiz_visibilities(context) : []
       cache_key_items = ['context_module_render_21_', context_module.cache_key, editable, is_student, can_view_unpublished,
-        true, Time.zone, Digest::MD5.hexdigest([visible_assignments, @section_visibility].join("/"))]
+        true, Time.zone, Digest::SHA256.hexdigest([visible_assignments, @section_visibility].join("/"))]
       cache_key = cache_key_items.join('/')
       cache_key = add_menu_tools_to_cache_key(cache_key)
       cache_key = add_mastery_paths_to_cache_key(cache_key, context, user)
@@ -52,7 +52,7 @@ module ContextModulesHelper
   def add_menu_tools_to_cache_key(cache_key)
     tool_key = @menu_tools ? @menu_tools.values.flatten.map(&:cache_key).join("/") : ""
     tool_key += @module_group_tools.to_s if @module_group_tools.present?
-    cache_key += Digest::MD5.hexdigest(tool_key) if tool_key.present?
+    cache_key += Digest::SHA256.hexdigest(tool_key) if tool_key.present?
     # should leave it alone if there are no tools
     cache_key
   end
@@ -64,7 +64,7 @@ module ContextModulesHelper
       else
         rules = ConditionalRelease::Service.active_rules(context, user, @session)
       end
-      cache_key += '/mastery:' + Digest::MD5.hexdigest(rules.to_s)
+      cache_key += '/mastery:' + Digest::SHA256.hexdigest(rules.to_s)
     end
     cache_key
   end

--- a/app/models/account_notification.rb
+++ b/app/models/account_notification.rb
@@ -241,7 +241,7 @@ class AccountNotification < ActiveRecord::Base
 
     if all_visible_account_ids || include_past
       # Refreshes every 10 minutes at the longest
-      all_account_ids_hash = Digest::MD5.hexdigest all_visible_account_ids.try(:sort).to_s
+      all_account_ids_hash = Digest::SHA256.hexdigest all_visible_account_ids.try(:sort).to_s
       Rails.cache.fetch(['account_notifications5', root_account, all_account_ids_hash, include_past].cache_key, expires_in: 10.minutes, &block)
     else
       # no point in doing an additional layer of caching for _only_ root accounts when root accounts are explicitly cached

--- a/app/models/context_external_tool.rb
+++ b/app/models/context_external_tool.rb
@@ -1163,7 +1163,7 @@ end
   end
 
   def self.key_for_granted_permissions(granted_permissions)
-    Digest::MD5.hexdigest(granted_permissions.sort_by{|k, v| k.to_s}.flatten.join(",")) # for consistency's sake
+    Digest::SHA256.hexdigest(granted_permissions.sort_by{|k, v| k.to_s}.flatten.join(",")) # for consistency's sake
   end
 
   # returns a key composed of the updated_at times for all the tools visible to someone with the granted_permissions
@@ -1179,7 +1179,7 @@ end
     # (which was fine when we only had two visibility settings but not when an infinite combination of permissions is in play)
     Rails.cache.fetch_with_batched_keys(compiled_key, batch_object: root_account, batched_keys: :global_navigation) do
       tools = self.filtered_global_navigation_tools(root_account, granted_permissions)
-      Digest::MD5.hexdigest(tools.sort.map(&:cache_key).join('/'))
+      Digest::SHA256.hexdigest(tools.sort.map(&:cache_key).join('/'))
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1623,7 +1623,7 @@ class User < ActiveRecord::Base
 
   def course_nickname_hash
     if preferences[:course_nicknames].present?
-      @nickname_hash ||= Digest::MD5.hexdigest(user_preference_values.where(:key => :course_nicknames).pluck(:sub_key, :value).sort.join(","))
+      @nickname_hash ||= Digest::SHA256.hexdigest(user_preference_values.where(:key => :course_nicknames).pluck(:sub_key, :value).sort.join(","))
     else
       "default"
     end
@@ -2061,7 +2061,7 @@ class User < ActiveRecord::Base
     return [] unless course_ids.present?
 
     shard.activate do
-      ids_hash = Digest::MD5.hexdigest(course_ids.sort.join(","))
+      ids_hash = Digest::SHA256.hexdigest(course_ids.sort.join(","))
       Rails.cache.fetch_with_batched_keys(['submissions_for_course_ids', ids_hash, start_at, limit].cache_key, expires_in: 1.day, batch_object: self, batched_keys: :submissions) do
         start_at ||= 4.weeks.ago
 

--- a/app/models/user_learning_object_scopes.rb
+++ b/app/models/user_learning_object_scopes.rb
@@ -127,8 +127,8 @@ module UserLearningObjectScopes
           return object_type.constantize.none # fallback
         end
       else
-        course_ids_cache_key = Digest::MD5.hexdigest(course_ids.sort.join('/'))
-        params_cache_key = Digest::MD5.hexdigest(ActiveSupport::Cache.expand_cache_key(params))
+        course_ids_cache_key = Digest::SHA256.hexdigest(course_ids.sort.join('/'))
+        params_cache_key = Digest::SHA256.hexdigest(ActiveSupport::Cache.expand_cache_key(params))
         cache_key = [self, "#{object_type}_needing_#{purpose}", course_ids_cache_key, params_cache_key].cache_key
 
         Rails.cache.fetch_with_batched_keys(cache_key, expires_in: expires_in, batch_object: self, batched_keys: :todo_list) do

--- a/config/initializers/active_support.rb
+++ b/config/initializers/active_support.rb
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
+Rails.application.config.active_support.use_sha1_digests = true
+
 ActiveSupport::TimeWithZone.delegate :to_yaml, :to => :utc
 ActiveSupport::SafeBuffer.class_eval do
   def encode_with(coder)

--- a/lib/assignment_override_applicator.rb
+++ b/lib/assignment_override_applicator.rb
@@ -353,7 +353,7 @@ module AssignmentOverrideApplicator
   # turn the list of overrides into a unique but consistent cache key component
   def self.overrides_hash(overrides)
     canonical = overrides.map{ |override| override.cache_key }.inspect
-    Digest::MD5.hexdigest(canonical)
+    Digest::SHA256.hexdigest(canonical)
   end
 
   # perform overrides of specific fields
@@ -408,7 +408,7 @@ module AssignmentOverrideApplicator
 
   def self.should_preload_override_students?(assignments, user, endpoint_key)
     return false unless user
-    assignment_key = Digest::MD5.hexdigest(assignments.map(&:id).sort.map(&:to_s).join(','))
+    assignment_key = Digest::SHA256.hexdigest(assignments.map(&:id).sort.map(&:to_s).join(','))
     key = ['should_preload_assignment_override_students', user.cache_key(:enrollments), user.cache_key(:groups), endpoint_key, assignment_key].cache_key
     # if the user has been touch we should preload all of the overrides because it's almost certain we'll need them all
     if Rails.cache.read(key)

--- a/lib/file_authenticator.rb
+++ b/lib/file_authenticator.rb
@@ -50,7 +50,7 @@ class FileAuthenticator
     # putting the user object in the cache key would, because this fingerprint
     # is not intended to differentiate caches of information _about_ the user.
     # just to differentiate caches _across_ user identities.
-    Digest::MD5.hexdigest("#{@user&.global_id}|#{@acting_as&.global_id}|#{@oauth_host}")
+    Digest::SHA256.hexdigest("#{@user&.global_id}|#{@acting_as&.global_id}|#{@oauth_host}")
   end
 
   def instfs_bearer_token

--- a/lib/math_man.rb
+++ b/lib/math_man.rb
@@ -29,7 +29,7 @@ module MathMan
   end
 
   def self.cache_key_for(latex, target)
-    ["mathman", dynamic_settings.fetch('version'), Digest::MD5.hexdigest(latex), target].compact.cache_key
+    ["mathman", dynamic_settings.fetch('version'), Digest::SHA256.hexdigest(latex), target].compact.cache_key
   end
 
   def self.use_for_mml?

--- a/lib/messageable_user/calculator.rb
+++ b/lib/messageable_user/calculator.rb
@@ -836,7 +836,7 @@ class MessageableUser
             methods.each do |method|
               canonical = send(method).cache_key
               shard_key << method
-              shard_key << Digest::MD5.hexdigest(canonical)
+              shard_key << Digest::SHA256.hexdigest(canonical)
             end
             by_shard[Shard.current] = Rails.cache.fetch(shard_key.cache_key, :expires_in => 1.day) { yield }
           end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -496,7 +496,7 @@ describe ApplicationHelper do
       key2 = collection_cache_key(collection)
       expect(key1).to eq key2
       # verify it's not overly long
-      expect(key1.length).to be <= 40
+      expect(key1.length).to be <= 128
 
       User.where(:id => collection[1]).update_all(:updated_at => 1.hour.ago)
       collection[1].reload

--- a/spec/lib/file_authenticator_spec.rb
+++ b/spec/lib/file_authenticator_spec.rb
@@ -39,7 +39,7 @@ describe FileAuthenticator do
 
   describe "fingerprint" do
     it "should be a hexdigest string" do
-      expect(@authenticator.fingerprint).to match(/^\h{32}$/)
+      expect(@authenticator.fingerprint).to match(/^\h{64}$/)
     end
 
     it "should be stable across instances with the same parameters" do


### PR DESCRIPTION
This is part of the FIPS compliance project

Changing the hashing algorithm for cache keys should not affect site operation

Test plan:
- specs pass