### PR TITLE
Use SHA256 for UUID on external feed items

### DIFF
--- a/app/models/external_feed.rb
+++ b/app/models/external_feed.rb
@@ -101,9 +101,9 @@ class ExternalFeed < ActiveRecord::Base
     if feed_type == :rss
       uuid = item.respond_to?(:guid) && item.guid && item.guid.content.to_s
       if uuid && uuid.length > 255
-        uuid = Digest::MD5.hexdigest(uuid)
+        uuid = Digest::SHA256.hexdigest(uuid)
       end
-      uuid ||= Digest::MD5.hexdigest("#{item.title}#{item.date.strftime('%Y-%m-%d')}")
+      uuid ||= Digest::SHA256.hexdigest("#{item.title}#{item.date.strftime('%Y-%m-%d')}")
 
       entry = self.external_feed_entries.where(uuid: uuid).first
       entry ||= self.external_feed_entries.where(url: item.link).first
@@ -137,7 +137,7 @@ class ExternalFeed < ActiveRecord::Base
       )
       return entry if entry.save
     elsif feed_type == :atom
-      uuid = item.id || Digest::MD5.hexdigest("#{item.title}#{item.published.utc.strftime('%Y-%m-%d')}")
+      uuid = item.id || Digest::SHA256.hexdigest("#{item.title}#{item.published.utc.strftime('%Y-%m-%d')}")
       entry = self.external_feed_entries.where(uuid: uuid).first
       entry ||= self.external_feed_entries.where(url: item.links.alternate.to_s).first
       author = item.authors.first || OpenObject.new

--- a/app/models/external_feed_entry.rb
+++ b/app/models/external_feed_entry.rb
@@ -37,7 +37,7 @@ class ExternalFeedEntry < ActiveRecord::Base
   sanitize_field :message, CanvasSanitize::SANITIZE
 
   def infer_defaults
-    self.uuid ||= Digest::MD5.hexdigest("#{title || rand.to_s}#{posted_at.strftime('%Y-%m-%d') rescue 'no-time'}")
+    self.uuid ||= Digest::SHA256.hexdigest("#{title || rand.to_s}#{posted_at.strftime('%Y-%m-%d') rescue 'no-time'}")
   end
   protected :infer_defaults
 


### PR DESCRIPTION
This is part of the FIPS compliance project

In some cases external feed entries can be missing the guid or have a guid
which is too long. Previously we were using an MD5 to generate a uuid
on our end. This change switches to using SHA256.

For existing entries, we fall back to matching on the entry link, so in most
cases this change should not result in duplicate feed entries being
added during the transition. Feeds that match based on the entry link will get
updated with the new uuid.

Test plan
- regression test rss and atom feeds