### PR TITLE
Use SHA256 for user tokens

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3112,7 +3112,7 @@ class User < ActiveRecord::Base
 
   # user tokens are returned by UserListV2 and used to bulk-enroll users using information that isn't easy to guess
   def self.token(id, uuid)
-    "#{id}_#{Digest::MD5.hexdigest(uuid)}"
+    "#{id}_#{Digest::SHA256.hexdigest(uuid)}"
   end
 
   def token

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3286,9 +3286,9 @@ describe User do
     let(:users) { [User.create!, @shard1.activate { User.create! }] }
     let(:tokens) { users.map(&:token) }
 
-    it "generates tokens made of id/md5(uuid) pairs" do
+    it "generates tokens made of id/hash(uuid) pairs" do
       tokens.each_with_index do |token, i|
-        expect(token).to eq "#{users[i].id}_#{Digest::MD5.hexdigest(users[i].uuid)}"
+        expect(token).to eq "#{users[i].id}_#{Digest::SHA256.hexdigest(users[i].uuid)}"
       end
     end
 


### PR DESCRIPTION
Change to SHA256 for user tokens returned by UserListV2 and used to bulk-enroll
users

This is part of the FIPS compliance project

Test plan
- regression test the "+ People" functionality on the course People page
   - when finding existing users and creating new users