### PR TITLE
Use SHA256 for generated filename during upload

### DIFF
--- a/app/models/importers/link_parser.rb
+++ b/app/models/importers/link_parser.rb
@@ -165,16 +165,16 @@ module Importers
     def link_embedded_image(info_match)
       extension = MIME::Types[info_match[:mime_type]]&.first&.extensions&.first
       image_data = Base64.decode64(info_match[:image])
-      md5 = Digest::MD5.hexdigest image_data
+      digest = Digest::SHA256.hexdigest image_data
       folder_name = I18n.t('embedded_images')
       @folder ||= Folder.root_folders(context).first.sub_folders.
         where(name: folder_name, workflow_state: 'hidden', context: context).first_or_create!
-      filename = "#{md5}.#{extension}"
-      file = Tempfile.new([md5, ".#{extension}"])
+      filename = "#{digest}.#{extension}"
+      file = Tempfile.new([digest, ".#{extension}"])
       file.binmode
       file.write(image_data)
       file.close
-      attachment = FileInContext.attach(context, file.path, display_name: filename, folder: @folder, explicit_filename: filename, md5: md5)
+      attachment = FileInContext.attach(context, file.path, display_name: filename, folder: @folder, explicit_filename: filename)
       resolved("#{context_path}/files/#{attachment.id}/preview")
     rescue
       unresolved(:file, rel_path: "#{folder_name}/#{filename}")

--- a/spec/lib/imported_html_converter_spec.rb
+++ b/spec/lib/imported_html_converter_spec.rb
@@ -224,7 +224,7 @@ describe ImportedHtmlConverter do
       new_string = convert_and_replace(test_string)
       attachment = Attachment.last
       expect(attachment.content_type).to eq 'image/gif'
-      expect(attachment.name).to eq "1d1fde3d669ed5c4fc68a49d643f140d.gif"
+      expect(attachment.name).to eq "7d8c0162b3f46d1e0ca56d53913d1cef67d672c0989c20141381a5f30f0bc481.gif"
       expect(new_string).to eq "<p><img src=\"/courses/#{@course.id}/files/#{attachment.id}/preview\"></p>"
     end
 


### PR DESCRIPTION
This is part of the FIPS compliance project

Test plan
- spec/lib/imported_html_converter_spec.rb passes
- have an import package with base64 image sources
- import the package into Canvas
- verify that the images are successfully imported