### PR TITLE
Pages publish/unpublish action triggers live event

### DIFF
--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -630,6 +630,20 @@ module Canvas::LiveEvents
                            })
   end
 
+  def self.wiki_page_published(page)
+    post_event_stringified("wiki_page_published", {
+                             wiki_page_id: page.global_id,
+                             title: LiveEvents.truncate(page.title)
+                           })
+  end
+
+  def self.wiki_page_unpublished(page)
+    post_event_stringified("wiki_page_unpublished", {
+                             wiki_page_id: page.global_id,
+                             title: LiveEvents.truncate(page.title)
+                           })
+  end
+
   def self.attachment_created(attachment)
     post_event_stringified("attachment_created", get_attachment_data(attachment))
   end

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -630,20 +630,6 @@ module Canvas::LiveEvents
                            })
   end
 
-  def self.wiki_page_published(page)
-    post_event_stringified("wiki_page_published", {
-                             wiki_page_id: page.global_id,
-                             title: LiveEvents.truncate(page.title)
-                           })
-  end
-
-  def self.wiki_page_unpublished(page)
-    post_event_stringified("wiki_page_unpublished", {
-                             wiki_page_id: page.global_id,
-                             title: LiveEvents.truncate(page.title)
-                           })
-  end
-
   def self.attachment_created(attachment)
     post_event_stringified("attachment_created", get_attachment_data(attachment))
   end

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -605,11 +605,12 @@ module Canvas::LiveEvents
                            })
   end
 
-  def self.wiki_page_updated(page, old_title, old_body)
+  def self.wiki_page_updated(page, old_title, old_body, old_workflow_state)
     payload = {
       wiki_page_id: page.global_id,
       title: LiveEvents.truncate(page.title),
-      body: LiveEvents.truncate(page.body)
+      body: LiveEvents.truncate(page.body),
+      workflow_state: page.workflow_state,
     }
 
     if old_title
@@ -618,6 +619,10 @@ module Canvas::LiveEvents
 
     if old_body
       payload[:old_body] = LiveEvents.truncate(old_body)
+    end
+
+    if old_workflow_state
+      payload[:old_workflow_state] = old_workflow_state
     end
 
     post_event_stringified("wiki_page_updated", payload)

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -135,6 +135,15 @@ module Canvas::LiveEventsCallbacks
                                              changes["title"]&.first,
                                              changes["body"]&.first)
       end
+      if changes["workflow_state"]
+        _old_state, new_state = changes["workflow_state"]
+        case new_state
+        when "active"
+          Canvas::LiveEvents.wiki_page_published(obj)
+        when "unpublished"
+          Canvas::LiveEvents.wiki_page_unpublished(obj)
+        end
+      end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)
     when AssignmentGroup

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -130,13 +130,10 @@ module Canvas::LiveEventsCallbacks
     when GroupMembership
       Canvas::LiveEvents.group_membership_updated(obj)
     when WikiPage
-      if changes["title"] || changes["body"]
+      if changes["title"] || changes["body"] || changes["workflow_state"]
         Canvas::LiveEvents.wiki_page_updated(obj,
                                              changes["title"]&.first,
                                              changes["body"]&.first)
-      end
-      if changes["workflow_state"]
-        Canvas::LiveEvents.wiki_page_updated(obj, nil, nil)
       end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -136,8 +136,9 @@ module Canvas::LiveEventsCallbacks
                                              changes["body"]&.first)
       end
       if changes["workflow_state"]
-          Canvas::LiveEvents.wiki_page_updated(obj)
-        end
+          Canvas::LiveEvents.wiki_page_updated(obj,
+                                             changes["title"]&.first,
+                                             changes["body"]&.first)
       end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -136,12 +136,7 @@ module Canvas::LiveEventsCallbacks
                                              changes["body"]&.first)
       end
       if changes["workflow_state"]
-        _old_state, new_state = changes["workflow_state"]
-        case new_state
-        when "active"
-          Canvas::LiveEvents.wiki_page_published(obj)
-        when "unpublished"
-          Canvas::LiveEvents.wiki_page_unpublished(obj)
+          Canvas::LiveEvents.wiki_page_updated(obj)
         end
       end
     when Assignment

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -136,9 +136,7 @@ module Canvas::LiveEventsCallbacks
                                              changes["body"]&.first)
       end
       if changes["workflow_state"]
-        Canvas::LiveEvents.wiki_page_updated(obj,
-                                             nil,
-                                             nil)
+        Canvas::LiveEvents.wiki_page_updated(obj, nil, nil)
       end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -137,8 +137,8 @@ module Canvas::LiveEventsCallbacks
       end
       if changes["workflow_state"]
           Canvas::LiveEvents.wiki_page_updated(obj,
-                                             changes["title"]&.first,
-                                             changes["body"]&.first)
+                                             nil,
+                                             nil
       end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -136,7 +136,7 @@ module Canvas::LiveEventsCallbacks
                                              changes["body"]&.first)
       end
       if changes["workflow_state"]
-          Canvas::LiveEvents.wiki_page_updated(obj,
+        Canvas::LiveEvents.wiki_page_updated(obj,
                                              nil,
                                              nil)
       end

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -138,7 +138,7 @@ module Canvas::LiveEventsCallbacks
       if changes["workflow_state"]
           Canvas::LiveEvents.wiki_page_updated(obj,
                                              nil,
-                                             nil
+                                             nil)
       end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -133,7 +133,8 @@ module Canvas::LiveEventsCallbacks
       if changes["title"] || changes["body"] || changes["workflow_state"]
         Canvas::LiveEvents.wiki_page_updated(obj,
                                              changes["title"]&.first,
-                                             changes["body"]&.first)
+                                             changes["body"]&.first,
+                                             changes["workflow_state"]&.first)
       end
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -331,6 +331,36 @@ describe Canvas::LiveEvents do
     end
   end
 
+  describe ".wiki_page_published" do
+    before do
+      course_with_teacher
+      @page = @course.wiki_pages.create(title: "a page", body: "some body", workflow_state: "unpublished")
+    end
+
+    it "posts a wiki_page_published event with the page id and title" do
+      expect_event("wiki_page_published", {
+                     wiki_page_id: @page.global_id.to_s,
+                     title: "a page"
+                   })
+      Canvas::LiveEvents.wiki_page_published(@page)
+    end
+  end
+
+  describe ".wiki_page_unpublished" do
+    before do
+      course_with_teacher
+      @page = @course.wiki_pages.create(title: "a page", body: "some body")
+    end
+
+    it "posts a wiki_page_unpublished event with the page id and title" do
+      expect_event("wiki_page_unpublished", {
+                     wiki_page_id: @page.global_id.to_s,
+                     title: "a page"
+                   })
+      Canvas::LiveEvents.wiki_page_unpublished(@page)
+    end
+  end
+
   describe ".conversation_forwarded" do
     before do
       @user1 = user_model

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -331,36 +331,6 @@ describe Canvas::LiveEvents do
     end
   end
 
-  describe ".wiki_page_published" do
-    before do
-      course_with_teacher
-      @page = @course.wiki_pages.create(title: "a page", body: "some body", workflow_state: "unpublished")
-    end
-
-    it "posts a wiki_page_published event with the page id and title" do
-      expect_event("wiki_page_published", {
-                     wiki_page_id: @page.global_id.to_s,
-                     title: "a page"
-                   })
-      Canvas::LiveEvents.wiki_page_published(@page)
-    end
-  end
-
-  describe ".wiki_page_unpublished" do
-    before do
-      course_with_teacher
-      @page = @course.wiki_pages.create(title: "a page", body: "some body")
-    end
-
-    it "posts a wiki_page_unpublished event with the page id and title" do
-      expect_event("wiki_page_unpublished", {
-                     wiki_page_id: @page.global_id.to_s,
-                     title: "a page"
-                   })
-      Canvas::LiveEvents.wiki_page_unpublished(@page)
-    end
-  end
-
   describe ".conversation_forwarded" do
     before do
       @user1 = user_model

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -290,15 +290,21 @@ describe Canvas::LiveEvents do
       @page = @course.wiki_pages.create(title: "old title", body: "old body")
     end
 
-    def wiki_page_updated
-      Canvas::LiveEvents.wiki_page_updated(@page, @page.title_changed? ? @page.title_was : nil, @page.body_changed? ? @page.body_was : nil)
+    def wiki_page_updated(old_workflow_state: nil)
+      Canvas::LiveEvents.wiki_page_updated(
+        @page,
+        @page.title_changed? ? @page.title_was : nil,
+        @page.body_changed? ? @page.body_was : nil,
+        old_workflow_state
+      )
     end
 
-    it "does not set old_title or old_body if they don't change" do
+    it "does not set old_title, old_body, or old_workflow_state if they don't change" do
       expect_event("wiki_page_updated", {
                      wiki_page_id: @page.global_id.to_s,
                      title: "old title",
-                     body: "old body"
+                     body: "old body",
+                     workflow_state: @page.workflow_state
                    })
 
       wiki_page_updated
@@ -311,7 +317,8 @@ describe Canvas::LiveEvents do
                      wiki_page_id: @page.global_id.to_s,
                      title: "new title",
                      old_title: "old title",
-                     body: "old body"
+                     body: "old body",
+                     workflow_state: @page.workflow_state
                    })
 
       wiki_page_updated
@@ -324,10 +331,23 @@ describe Canvas::LiveEvents do
                      wiki_page_id: @page.global_id.to_s,
                      title: "old title",
                      body: "new body",
-                     old_body: "old body"
+                     old_body: "old body",
+                     workflow_state: @page.workflow_state
                    })
 
       wiki_page_updated
+    end
+
+    it "sets old_workflow_state if the workflow_state changed" do
+      expect_event("wiki_page_updated", {
+                     wiki_page_id: @page.global_id.to_s,
+                     title: "old title",
+                     body: "old body",
+                     workflow_state: @page.workflow_state,
+                     old_workflow_state: "unpublished"
+                   })
+
+      wiki_page_updated(old_workflow_state: "unpublished")
     end
   end
 

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -106,6 +106,26 @@ describe LiveEventsObserver do
       expect(Canvas::LiveEvents).to receive(:wiki_page_deleted).once
       @page.destroy_permanently!
     end
+
+    it "posts published event when page is published" do
+      wiki_page_model(workflow_state: "unpublished")
+      expect(Canvas::LiveEvents).to receive(:wiki_page_published).once
+      @page.publish!
+    end
+
+    it "posts unpublished event when page is unpublished" do
+      wiki_page_model
+      expect(Canvas::LiveEvents).to receive(:wiki_page_unpublished).once
+      @page.unpublish!
+    end
+
+    it "does not post published/unpublished event when only title changes" do
+      wiki_page_model
+      expect(Canvas::LiveEvents).not_to receive(:wiki_page_published)
+      expect(Canvas::LiveEvents).not_to receive(:wiki_page_unpublished)
+      @page.title = "new title"
+      @page.save
+    end
   end
 
   describe "attachment" do

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -77,14 +77,14 @@ describe LiveEventsObserver do
 
     it "posts update events for title" do
       wiki_page_model(title: "old title")
-      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, "old title", nil)
+      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, "old title", nil, nil)
       @page.title = "new title"
       @page.save
     end
 
     it "posts update events for body" do
       wiki_page_model(body: "old body")
-      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, "old body")
+      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, "old body", nil)
       @page.body = "new body"
       @page.save
     end
@@ -109,13 +109,13 @@ describe LiveEventsObserver do
 
     it "posts update event when page is published" do
       wiki_page_model(workflow_state: "unpublished")
-      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil).once
+      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil, "unpublished").once
       @page.publish!
     end
 
     it "posts update event when page is unpublished" do
       wiki_page_model
-      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil).once
+      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil, "active").once
       @page.unpublish!
     end
   end

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -107,22 +107,21 @@ describe LiveEventsObserver do
       @page.destroy_permanently!
     end
 
-    it "posts published event when page is published" do
+    it "posts update event when page is published" do
       wiki_page_model(workflow_state: "unpublished")
-      expect(Canvas::LiveEvents).to receive(:wiki_page_published).once
+      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil).once
       @page.publish!
     end
 
-    it "posts unpublished event when page is unpublished" do
+    it "posts update event when page is unpublished" do
       wiki_page_model
-      expect(Canvas::LiveEvents).to receive(:wiki_page_unpublished).once
+      expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil).once
       @page.unpublish!
     end
 
-    it "does not post published/unpublished event when only title changes" do
+    it "does not post workflow_state update event when only title changes" do
       wiki_page_model
-      expect(Canvas::LiveEvents).not_to receive(:wiki_page_published)
-      expect(Canvas::LiveEvents).not_to receive(:wiki_page_unpublished)
+      expect(Canvas::LiveEvents).not_to receive(:wiki_page_updated).with(anything, nil, nil)
       @page.title = "new title"
       @page.save
     end

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -118,13 +118,6 @@ describe LiveEventsObserver do
       expect(Canvas::LiveEvents).to receive(:wiki_page_updated).with(@page, nil, nil).once
       @page.unpublish!
     end
-
-    it "does not post workflow_state update event when only title changes" do
-      wiki_page_model
-      expect(Canvas::LiveEvents).not_to receive(:wiki_page_updated).with(anything, nil, nil)
-      @page.title = "new title"
-      @page.save
-    end
   end
 
   describe "attachment" do


### PR DESCRIPTION
In response to [Atomic Search Issue 647](https://github.com/atomicjolt/atomic-search/issues/647).

Defined two new methods in [`lib/canvas/live_events.rb`](https://github.com/atomicjolt/canvas-lms/blob/bs/pages-publish-trigger-live-event_AS-647/lib/canvas/live_events.rb), `wiki_page_published` and `wiki_page_unpublished`.

In [`lib/canvas/live_events_callbacks.rb`](https://github.com/atomicjolt/canvas-lms/blob/bs/pages-publish-trigger-live-event_AS-647/lib/canvas/live_events_callbacks.rb), the `workflow_state` of `WikiPage` is monitored and calls one of the two methods above when the state is changed to `active` or `unpublished`.