### PR TITLE
Classic quiz with assignment. When creating or updating a quiz questi…

### DIFF
--- a/app/observers/live_events_observer.rb
+++ b/app/observers/live_events_observer.rb
@@ -53,6 +53,7 @@ class LiveEventsObserver < ActiveRecord::Observer
           :user_account_association,
           :user,
           :wiki_page,
+          "Quizzes::QuizQuestion",
           "MasterCourses::MasterTemplate",
           "MasterCourses::MasterMigration",
           "MasterCourses::ChildSubscription",

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -46,6 +46,9 @@ module Canvas::LiveEventsCallbacks
       Canvas::LiveEvents.group_membership_created(obj)
     when WikiPage
       Canvas::LiveEvents.wiki_page_created(obj)
+    when Quizzes::QuizQuestion
+      assignment = obj.quiz&.assignment
+      Canvas::LiveEvents.assignment_updated(assignment) if assignment
     when Assignment
       Canvas::LiveEvents.assignment_created(obj)
     when AssignmentGroup
@@ -135,6 +138,9 @@ module Canvas::LiveEventsCallbacks
                                              changes["title"]&.first,
                                              changes["body"]&.first)
       end
+    when Quizzes::QuizQuestion
+      assignment = obj.quiz&.assignment
+      Canvas::LiveEvents.assignment_updated(assignment) if assignment
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)
     when AssignmentGroup

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -433,6 +433,25 @@ describe LiveEventsObserver do
     end
   end
 
+  describe "quiz_question" do
+    it "posts assignment_updated when a question is created" do
+      allow(Canvas::LiveEvents).to receive(:assignment_updated)
+      quiz_model(quiz_type: "assignment")
+      assignment = @quiz.reload.assignment
+      expect(Canvas::LiveEvents).to receive(:assignment_updated).with(assignment)
+      @quiz.quiz_questions.create!(question_data: { name: "Q1", question_type: "true_false_question", points_possible: 1 })
+    end
+
+    it "posts assignment_updated when a question is updated" do
+      allow(Canvas::LiveEvents).to receive(:assignment_updated)
+      quiz_model(quiz_type: "assignment")
+      question = @quiz.quiz_questions.create!(question_data: { name: "Q1", question_type: "true_false_question", points_possible: 1 })
+      assignment = @quiz.reload.assignment
+      expect(Canvas::LiveEvents).to receive(:assignment_updated).with(assignment)
+      question.update!(question_data: { name: "Q1 updated", question_type: "true_false_question", points_possible: 1 })
+    end
+  end
+
   describe "content_migration_completed" do
     it "posts update events" do
       expect(Canvas::LiveEvents).to receive(:content_migration_completed).once


### PR DESCRIPTION
Live event triggers when creating or updating a quiz question for a classic quiz with an assignment.
Created two test cases for these changes. Both pass.
Did manually testing with test Kinesis server. Both creating and updating a quiz question trigger a live event.

Was prompted to include `"Quizzes::QuizQuestion"` in the Live Event Observer. Claude did not have any insight on how to make the code any more uniform.