### PR TITLE
Discussion Replies - Edit/Delete Triggers Live Event

### DIFF
--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -155,8 +155,7 @@ module Canvas::LiveEvents
       created_at: entry.created_at,
       discussion_entry_id: entry.id,
       discussion_topic_id: entry.discussion_topic_id,
-      text: LiveEvents.truncate(entry.message),
-      workflow_state: entry.workflow_state
+      text: LiveEvents.truncate(entry.message)
     }
 
     payload[:parent_discussion_entry_id] = entry.parent_id if entry.parent_id

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -138,6 +138,10 @@ module Canvas::LiveEvents
     post_event_stringified("discussion_entry_created", get_discussion_entry_data(entry))
   end
 
+  def self.discussion_entry_updated(entry)
+    post_event_stringified("discussion_entry_updated", get_discussion_entry_data(entry))
+  end
+
   def self.discussion_entry_submitted(entry, assignment_id, submission_id)
     payload = get_discussion_entry_data(entry)
     payload[:assignment_id] = assignment_id unless assignment_id.nil?
@@ -151,7 +155,8 @@ module Canvas::LiveEvents
       created_at: entry.created_at,
       discussion_entry_id: entry.id,
       discussion_topic_id: entry.discussion_topic_id,
-      text: LiveEvents.truncate(entry.message)
+      text: LiveEvents.truncate(entry.message),
+      workflow_state: entry.workflow_state
     }
 
     payload[:parent_discussion_entry_id] = entry.parent_id if entry.parent_id

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -142,6 +142,10 @@ module Canvas::LiveEvents
     post_event_stringified("discussion_entry_updated", get_discussion_entry_data(entry))
   end
 
+  def self.discussion_entry_deleted(entry)
+    post_event_stringified("discussion_entry_deleted", get_discussion_entry_data(entry))
+  end
+
   def self.discussion_entry_submitted(entry, assignment_id, submission_id)
     payload = get_discussion_entry_data(entry)
     payload[:assignment_id] = assignment_id unless assignment_id.nil?

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -116,7 +116,11 @@ module Canvas::LiveEventsCallbacks
       end
       Canvas::LiveEvents.course_updated(obj)
     when DiscussionEntry
-      Canvas::LiveEvents.discussion_entry_updated(obj)
+      if changes["deleted_at"] && obj.deleted?
+        Canvas::LiveEvents.discussion_entry_deleted(obj)
+      else
+        Canvas::LiveEvents.discussion_entry_updated(obj)
+      end
     when DiscussionTopic
       Canvas::LiveEvents.discussion_topic_updated(obj)
     when Enrollment

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -115,6 +115,8 @@ module Canvas::LiveEventsCallbacks
         Canvas::LiveEvents.course_syllabus_updated(obj, changes["syllabus_body"].first)
       end
       Canvas::LiveEvents.course_updated(obj)
+    when DiscussionEntry
+      Canvas::LiveEvents.discussion_entry_updated(obj)
     when DiscussionTopic
       Canvas::LiveEvents.discussion_topic_updated(obj)
     when Enrollment

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -1888,6 +1888,53 @@ describe Canvas::LiveEvents do
     end
   end
 
+  describe ".discussion_entry_updated" do
+    it "triggers a discussion entry updated live event" do
+      course_with_student
+      topic = @course.discussion_topics.create!(title: "test title", message: "test body")
+      entry = topic.discussion_entries.create!(message: "<p>original</p>", user_id: @student.id)
+
+      expect_event("discussion_entry_updated", {
+        user_id: entry.user_id.to_s,
+        created_at: entry.created_at,
+        discussion_entry_id: entry.id.to_s,
+        discussion_topic_id: entry.discussion_topic_id.to_s,
+        text: entry.message,
+        workflow_state: entry.workflow_state
+      }).once
+
+      Canvas::LiveEvents.discussion_entry_updated(entry)
+    end
+
+    it "includes workflow_state deleted when entry is soft deleted" do
+      course_with_student
+      topic = @course.discussion_topics.create!(title: "test title", message: "test body")
+      entry = topic.discussion_entries.create!(message: "<p>original</p>", user_id: @student.id)
+      entry.destroy
+
+      expect_event("discussion_entry_updated", hash_including(
+        discussion_entry_id: entry.id.to_s,
+        workflow_state: "deleted"
+      )).once
+
+      Canvas::LiveEvents.discussion_entry_updated(entry)
+    end
+
+    it "includes parent_discussion_entry_id for nested replies" do
+      course_with_student
+      topic = @course.discussion_topics.create!(title: "test title", message: "test body")
+      parent = topic.discussion_entries.create!(message: "parent", user_id: @student.id)
+      reply = topic.discussion_entries.create!(message: "reply", user_id: @student.id, parent_id: parent.id)
+
+      expect_event("discussion_entry_updated", hash_including(
+        discussion_entry_id: reply.id.to_s,
+        parent_discussion_entry_id: parent.id.to_s
+      )).once
+
+      Canvas::LiveEvents.discussion_entry_updated(reply)
+    end
+  end
+
   describe ".discussion_entry_submitted" do
     context "with non graded discussion" do
       it "creates a discussion entry created live event" do
@@ -1906,7 +1953,8 @@ describe Canvas::LiveEvents do
                        created_at: entry.created_at,
                        discussion_entry_id: entry.id.to_s,
                        discussion_topic_id: entry.discussion_topic_id.to_s,
-                       text: entry.message
+                       text: entry.message,
+                       workflow_state: entry.workflow_state
                      }).once
 
         Canvas::LiveEvents.discussion_entry_submitted(entry, nil, nil)
@@ -1935,7 +1983,8 @@ describe Canvas::LiveEvents do
                        created_at: entry.created_at,
                        discussion_entry_id: entry.id.to_s,
                        discussion_topic_id: entry.discussion_topic_id.to_s,
-                       text: entry.message
+                       text: entry.message,
+                       workflow_state: entry.workflow_state
                      }).once
 
         Canvas::LiveEvents.discussion_entry_submitted(entry, assignment.id, submission.id)

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -1899,23 +1899,8 @@ describe Canvas::LiveEvents do
         created_at: entry.created_at,
         discussion_entry_id: entry.id.to_s,
         discussion_topic_id: entry.discussion_topic_id.to_s,
-        text: entry.message,
-        workflow_state: entry.workflow_state
+        text: entry.message
       }).once
-
-      Canvas::LiveEvents.discussion_entry_updated(entry)
-    end
-
-    it "includes workflow_state deleted when entry is soft deleted" do
-      course_with_student
-      topic = @course.discussion_topics.create!(title: "test title", message: "test body")
-      entry = topic.discussion_entries.create!(message: "<p>original</p>", user_id: @student.id)
-      entry.destroy
-
-      expect_event("discussion_entry_updated", hash_including(
-        discussion_entry_id: entry.id.to_s,
-        workflow_state: "deleted"
-      )).once
 
       Canvas::LiveEvents.discussion_entry_updated(entry)
     end
@@ -1953,8 +1938,7 @@ describe Canvas::LiveEvents do
                        created_at: entry.created_at,
                        discussion_entry_id: entry.id.to_s,
                        discussion_topic_id: entry.discussion_topic_id.to_s,
-                       text: entry.message,
-                       workflow_state: entry.workflow_state
+                       text: entry.message
                      }).once
 
         Canvas::LiveEvents.discussion_entry_submitted(entry, nil, nil)
@@ -1983,8 +1967,7 @@ describe Canvas::LiveEvents do
                        created_at: entry.created_at,
                        discussion_entry_id: entry.id.to_s,
                        discussion_topic_id: entry.discussion_topic_id.to_s,
-                       text: entry.message,
-                       workflow_state: entry.workflow_state
+                       text: entry.message
                      }).once
 
         Canvas::LiveEvents.discussion_entry_submitted(entry, assignment.id, submission.id)

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -1920,6 +1920,24 @@ describe Canvas::LiveEvents do
     end
   end
 
+  describe ".discussion_entry_deleted" do
+    it "triggers a discussion entry deleted live event" do
+      course_with_student
+      topic = @course.discussion_topics.create!(title: "test title", message: "test body")
+      entry = topic.discussion_entries.create!(message: "<p>original</p>", user_id: @student.id)
+
+      expect_event("discussion_entry_deleted", {
+        user_id: entry.user_id.to_s,
+        created_at: entry.created_at,
+        discussion_entry_id: entry.id.to_s,
+        discussion_topic_id: entry.discussion_topic_id.to_s,
+        text: entry.message
+      }).once
+
+      Canvas::LiveEvents.discussion_entry_deleted(entry)
+    end
+  end
+
   describe ".discussion_entry_submitted" do
     context "with non graded discussion" do
       it "creates a discussion entry created live event" do

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -197,11 +197,11 @@ describe LiveEventsObserver do
       entry.save
     end
 
-    it "posts update events when soft deleted" do
+    it "posts delete events when soft deleted" do
       course_model
       discussion_topic_model(context: @course)
       entry = @topic.discussion_entries.create!(message: "entry")
-      expect(Canvas::LiveEvents).to receive(:discussion_entry_updated).once
+      expect(Canvas::LiveEvents).to receive(:discussion_entry_deleted).once
       entry.destroy
     end
   end

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -187,6 +187,23 @@ describe LiveEventsObserver do
       discussion_topic_model(context: @course)
       @topic.discussion_entries.create!(message: "entry")
     end
+
+    it "posts update events" do
+      course_model
+      discussion_topic_model(context: @course)
+      entry = @topic.discussion_entries.create!(message: "entry")
+      expect(Canvas::LiveEvents).to receive(:discussion_entry_updated).once
+      entry.message = "edited"
+      entry.save
+    end
+
+    it "posts update events when soft deleted" do
+      course_model
+      discussion_topic_model(context: @course)
+      entry = @topic.discussion_entries.create!(message: "entry")
+      expect(Canvas::LiveEvents).to receive(:discussion_entry_updated).once
+      entry.destroy
+    end
   end
 
   describe "group" do


### PR DESCRIPTION
Editing or deleting a reply as part of a discussion thread will trigger a live event.
Includes automated tests.
Tested manually with Kinesis server.

Created new discussion_entry_updated function as one did not exist.