### PR TITLE
added live events for when a file (attachment) is published or unpublished (locked)

### DIFF
--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -457,6 +457,7 @@ module Canvas::LiveEvents
       folder_id: attachment.global_folder_id,
       unlock_at: attachment.unlock_at,
       lock_at: attachment.lock_at,
+      locked: attachment.locked,
       updated_at: attachment.updated_at
     }
   end

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -143,7 +143,7 @@ module Canvas::LiveEventsCallbacks
       Canvas::LiveEvents.assignment_override_updated(obj)
     when Attachment
       if attachment_eligible?(obj)
-        if %w[display_name lock_at unlock_at folder_id].any? { |field| changes[field] }
+        if %w[display_name lock_at unlock_at folder_id locked].any? { |field| changes[field] }
           Canvas::LiveEvents.attachment_updated(obj, changes["display_name"]&.first)
         elsif changes["file_state"] && obj.file_state == "deleted"
           # Attachments are often soft deleted rather than destroyed

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -137,6 +137,21 @@ describe LiveEventsObserver do
         attachment.touch
       end
     end
+
+    context "if the attachment is published" do
+      it "posts attachment_updated event" do
+        attachment.update(locked: true)
+        expect(Canvas::LiveEvents).to receive(:attachment_updated)
+        attachment.publish!
+      end
+    end
+
+    context "if the attachment is unpublished" do
+      it "posts attachment_updated event" do
+        expect(Canvas::LiveEvents).to receive(:attachment_updated)
+        attachment.update(locked: true)
+      end
+    end
   end
 
   describe "conversation" do


### PR DESCRIPTION
Added live events for when a file (attachment) is published or unpublished (unlocked or locked).